### PR TITLE
More configuration options for Consul checks

### DIFF
--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -5,16 +5,38 @@
 # Parameters:
 #   $url:
 #     The URL for consul
+#   $catalog_checks:
+#       Whether to perform checks against the Consul service Catalog
+#       Optional.
+#   $new_leader_checks:
+#       Whether to enable new leader checks from this agent
+#       Note: if this is set on multiple agents in the same cluster
+#       you will receive one event per leader change per agent
+#   $service_whitelist
+#       Services to restrict catalog querying to
+#       The default settings query up to 50 services. So if you have more than
+#       this many in your Consul service catalog, you will want to fill in the
+#       whitelist
 #
 # Sample Usage:
 #
 #   class { 'datadog_agent::integrations::consul' :
 #     url  => "http://localhost:8500"
+#     catalog_checks    => true,
+#     new_leader_checks => false,
 #   }
 #
 class datadog_agent::integrations::consul(
-  $url = 'http://localhost:8500'
+  $url               = 'http://localhost:8500',
+  $catalog_checks    = true,
+  $new_leader_checks = true,
+  $service_whitelist = []
 ) inherits datadog_agent::params {
+
+  validate_string($url)
+  validate_bool($catalog_checks)
+  validate_bool($new_leader_checks)
+  validate_array($service_whitelist)
 
   file { "${datadog_agent::params::conf_dir}/consul.yaml":
     ensure  => file,

--- a/templates/agent-conf.d/consul.yaml.erb
+++ b/templates/agent-conf.d/consul.yaml.erb
@@ -22,12 +22,12 @@ instances:
       # ca_bundle_file: '/path/to/trusted_ca_bundle_file'
 
       # Whether to perform checks against the Consul service Catalog
-      catalog_checks: yes
+      catalog_checks: <%= @catalog_checks ? 'yes' : 'no' %>
 
       # Whether to enable new leader checks from this agent
       # Note: if this is set on multiple agents in the same cluster
       # you will receive one event per leader change per agent
-      new_leader_checks: yes
+      new_leader_checks: <%= @new_leader_checks ? 'yes' : 'no' %>
 
       # Services to restrict catalog querying to
       # The default settings query up to 50 services. So if you have more than
@@ -37,3 +37,11 @@ instances:
       #  - zookeeper
       #  - gunicorn
       #  - redis
+      <% if @service_whitelist and ! @service_whitelist.empty? -%>
+      service_whitelist:
+        <%- Array(@service_whitelist).each do |svc| -%>
+          <%- if svc != '' -%>
+          - <%= svc %>
+          <%- end -%>
+        <%- end -%>
+      <% end -%>


### PR DESCRIPTION
This improves the (now included) Consul check, allowing additional customisation.

Ported from https://github.com/vend/puppet-datadog-agent/pull/4
