### PR TITLE
Avoid apt update

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -33,11 +33,6 @@ class datadog_agent::ubuntu(
     require => Package['apt-transport-https'],
   }
 
-  exec { 'datadog_apt-get_update':
-    command     => '/usr/bin/apt-get update',
-    refreshonly => true,
-  }
-
   package { 'datadog-agent-base':
     ensure => absent,
     before => Package['datadog-agent'],

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -46,7 +46,8 @@ class datadog_agent::ubuntu(
 
   package { 'datadog-agent':
     ensure  => $agent_version,
-    require => [File['/etc/apt/sources.list.d/datadog.list']],
+    require => [File['/etc/apt/sources.list.d/datadog.list'],
+                Exec['datadog_apt-get_update']],
   }
 
   service { 'datadog-agent':

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -29,6 +29,7 @@ class datadog_agent::ubuntu(
     source  => 'puppet:///modules/datadog_agent/datadog.list',
     owner   => 'root',
     group   => 'root',
+    replace => 'no',
     notify  => Exec['datadog_apt-get_update'],
     require => Package['apt-transport-https'],
   }
@@ -45,8 +46,7 @@ class datadog_agent::ubuntu(
 
   package { 'datadog-agent':
     ensure  => $agent_version,
-    require => [File['/etc/apt/sources.list.d/datadog.list'],
-                Exec['datadog_apt-get_update']],
+    require => [File['/etc/apt/sources.list.d/datadog.list']],
   }
 
   service { 'datadog-agent':

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -33,6 +33,11 @@ class datadog_agent::ubuntu(
     require => Package['apt-transport-https'],
   }
 
+  exec { 'datadog_apt-get_update':
+    command     => '/usr/bin/apt-get update',
+    refreshonly => true,
+  }
+
   package { 'datadog-agent-base':
     ensure => absent,
     before => Package['datadog-agent'],


### PR DESCRIPTION
 * do not override dd apt's source file should file already exist. (this will prevent `apt-get update` from triggering`)